### PR TITLE
ステップ4 ユーザ + 管理者

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 gem 'kaminari'
 
 # Use ActiveStorage variant

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
+    bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.7.0)
       msgpack (~> 1.0)
@@ -231,6 +232,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)

--- a/app/assets/javascripts/admin/users.coffee
+++ b/app/assets/javascripts/admin/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/sessions.coffee
+++ b/app/assets/javascripts/sessions.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Admin::Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,3 +18,7 @@
 .alert {
   margin-top: 20px;
 }
+
+.table {
+  margin-top: 20px;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,3 +14,7 @@
  *= require_self
  *= require bootstrap/dist/css/bootstrap.min
  */
+
+.alert {
+  margin-top: 20px;
+}

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < ApplicationController
-  before_action :set_user, only: [:edit, :update, :destroy]
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
   before_action :user_admin?
 
   def index
@@ -20,6 +20,9 @@ class Admin::UsersController < ApplicationController
     end
   end
 
+  def show
+  end
+
   def edit
   end
 
@@ -28,14 +31,18 @@ class Admin::UsersController < ApplicationController
       redirect_to admin_user_url(@user)
       flash[:success] = "ユーザー「#{@user.name}」を更新しました"
     else
-      render :edit
+    flash[:notice] = "少なくとも1人、管理権限をもつユーザーが必要の為、更新できません。"
+    redirect_to admin_users_path
     end
   end
 
   def destroy
     if @user.destroy
-    redirect_to admin_user_url
+    redirect_to admin_users_url
     flash[:danger] = "ユーザー「#{@user.name}」を削除しました"
+    else
+    flash[:notice] = "少なくとも1人、管理権限をもつユーザーが必要の為、削除できません。"
+    redirect_to admin_users_path
     end
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,9 @@
 class Admin::UsersController < ApplicationController
   before_action :set_user, only: [:edit, :update, :destroy]
+  before_action :user_admin?
 
   def index
-    @users = User.all
+    @users = User.all.order(created_at: :desc)
   end
 
   def new
@@ -32,9 +33,10 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
-    @user.destroy
+    if @user.destroy
     redirect_to admin_user_url
     flash[:danger] = "ユーザー「#{@user.name}」を削除しました"
+    end
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,50 @@
+class Admin::UsersController < ApplicationController
+  before_action :set_user, only: [:edit, :update, :destroy]
+
+  def index
+    @users = User.all
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      flash[:notice] = "ユーザー「#{@user.name}」を登録しました"
+      redirect_to admin_user_url(@user)
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_url(@user)
+      flash[:success] = "ユーザー「#{@user.name}」を更新しました"
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @user.destroy
+    redirect_to admin_user_url
+    flash[:danger] = "ユーザー「#{@user.name}」を削除しました"
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+  include SessionsHelper
+  before_action :current_user
+
+  def authenticate_user
+    if current_user == nil
+      flash[:notice] = "ログインが必要です！"
+      redirect_to new_session_path
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,20 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
-  before_action :current_user
+  # before_action :current_user
 
   def authenticate_user
     if current_user == nil
       flash[:notice] = "ログインが必要です！"
       redirect_to new_session_path
+    end
+  end
+
+  def current_user?
+    @user = User.find(params[:id])
+    if @user != current_user
+      flash[:notice] = "閲覧権限がありません"
+      redirect_to tasks_path
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,19 +1,18 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
-  # before_action :current_user
+  before_action :current_user
 
   def authenticate_user
-    if current_user == nil
-      flash[:notice] = "ログインが必要です！"
-      redirect_to new_session_path
+    if current_user.nil?
+    flash[:notice] = "ログインが必要です！"
+    redirect_to new_session_path
     end
   end
 
-  def current_user?
-    @user = User.find(params[:id])
-    if @user != current_user
-      flash[:notice] = "閲覧権限がありません"
+  def user_admin?
+    unless current_user.admin?
+      flash[:danger] = "権限がありません"
       redirect_to tasks_path
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,22 @@
+class SessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    user = User.find_by(email: params[:session][:email].downcase)
+    if user && user.authenticate(params[:session][:password])
+      session[:user_id] = user.id
+      flash[:success] = 'ログインしました'
+      redirect_to user_path(user.id)
+    else
+      flash[:danger] = 'ログインに失敗しました'
+      render :new
+    end
+  end
+
+  def destroy
+    session.delete(:user_id)
+    flash[:notice] = 'ログアウトしました'
+    redirect_to new_session_path
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 class TasksController < ApplicationController
   before_action :authenticate_user
-  
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
+
 
   def index
     if params[:sort_expired] || params[:sort_priority]
@@ -23,7 +24,6 @@ class TasksController < ApplicationController
    end
 
   def show
-    @task = Task.find(params[:id])
   end
 
   def new
@@ -31,7 +31,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    @task = current_user.tasks.build(task_params)
     if @task.save
       flash[:notice] = "タスク「#{@task.title}」を登録しました"
       redirect_to tasks_path
@@ -41,24 +41,25 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = Task.find(params[:id])
   end
 
   def update
-    task = Task.find(params[:id])
-    task.update(task_params)
-    flash[:success] = "タスク「#{task.title}」を更新しました"
+    @task.update(task_params)
+    flash[:success] = "タスク「#{@task.title}」を更新しました"
     redirect_to tasks_path
   end
 
   def destroy
-    task = Task.find(params[:id])
-    task.destroy
-    flash[:danger] = "タスク「#{task.title}」を削除しました"
+    @task.destroy
+    flash[:danger] = "タスク「#{@task.title}」を削除しました"
     redirect_to tasks_path
   end
 
   private
+  def set_task
+    @task = Task.find(params[:id])
+  end
+
   def task_params
     params.require(:task).permit(:title, :content, :deadline, :status, :priority)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,5 @@
 class TasksController < ApplicationController
+  before_action :authenticate_user
   def index
     if params[:sort_expired] || params[:sort_priority]
       if params[:sort_expired]

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,7 @@
 class TasksController < ApplicationController
   before_action :authenticate_user
+  
+
   def index
     if params[:sort_expired] || params[:sort_priority]
       if params[:sort_expired]

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,6 @@ class TasksController < ApplicationController
   before_action :authenticate_user
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
-
   def index
     if params[:sort_expired] || params[:sort_priority]
       if params[:sort_expired]
@@ -57,7 +56,11 @@ class TasksController < ApplicationController
 
   private
   def set_task
-    @task = Task.find(params[:id])
+    if current_user.admin?
+      @task = Task.find(params[:id])
+    else
+      @task = current_user.tasks.find(params[:id])
+    end
   end
 
   def task_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,14 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      redirect_to user_path(@user.id)
     else
      render :new
     end
+  end
+
+  def show
+    @user = User.find(params[:id])
   end
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,4 +2,17 @@ class UsersController < ApplicationController
   def new
     @user = User.new
   end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+    else
+     render :new
+    end
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password,
+                                 :password_confirmation)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :current_user?, only: [:show]
+
   def new
     @user = User.new
   end
@@ -6,6 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      session[:user_id] = @user.id
       redirect_to user_path(@user.id)
     else
      render :new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 class UsersController < ApplicationController
   before_action :current_user?, only: [:show]
-
   def new
     @user = User.new
   end
@@ -16,11 +15,25 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
   end
 
+  def destroy
+    @user.destroy
+    flash[:danger] = "ユーザー「#{@user.name}」を削除しました"
+    redirect_to new_user_path
+  end
+
+  private
   def user_params
     params.require(:user).permit(:name, :email, :password,
                                  :password_confirmation)
+  end
+
+  def current_user?
+    @user = User.find(params[:id])
+    if @user != current_user
+    flash[:notice] = "閲覧権限がありません"
+    redirect_to tasks_path
+    end
   end
 end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,9 @@
+module SessionsHelper
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+
+  def logged_in?
+    current_user.present?
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -10,4 +10,6 @@ class Task < ApplicationRecord
 
  scope :title_search, ->(title) { where('title LIKE ?',"%#{title}%") }
  scope :status_search, ->(status) { where(status: status) }
+
+ belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,9 @@
 class User < ApplicationRecord
   has_many :tasks
+  before_validation { email.downcase! }
   has_secure_password
+  validates :name,  presence: true, length: { maximum: 30 }
+  validates :email, presence: true, length: { maximum: 255 },
+                    format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :password, presence: true, length: { minimum: 6 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,20 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   validates :password, presence: true, length: { minimum: 6 }
+  before_destroy :least_one_admin_user_destroy
+  before_update :least_one_admin_user_update
+
+  private
+  def least_one_admin_user_destroy
+    if User.where(admin: true).count == 1 && self.admin
+    throw(:abort)
+    end
+  end
+
+  def least_one_admin_user_update
+    user = User.where(id: self.id).where(admin: true)
+    if User.where(admin: true).count == 1 && user.present? && self.admin == false
+     throw(:abort)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,4 @@
 class User < ApplicationRecord
+  has_many :tasks
+  has_secure_password
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,25 @@
+<% if @user.errors.any? %>
+  <div id="error_explanation" class="alert-danger">
+    <h2><%= @user.errors.count %>件のエラーがあります。</h2>
+    <ul>
+    <% @user.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+<div class="col-md-4">
+<%= form_with(model: [:admin, @user], local: true) do |f| %>
+  <div class="form-group">
+    <%= f.text_field :name, placeholder:"名前", class: 'form-control' %><br>
+    <%= f.email_field :email, placeholder:"メールアドレス", class: 'form-control' %><br>
+    <%= f.password_field :password, placeholder:"パスワード", class: 'form-control' %><br>
+    <%= f.password_field :password_confirmation, placeholder:"パスワード確認", class: 'form-control' %><br>
+    <%= f.hidden_field :admin, value: false %>
+    <%= f.check_box :admin, {}, true, false %>
+    <%= f.label :admin, "管理者権限" %><br>
+  </div>
+  <%= f.submit '登録', class: 'btn btn-primary', id: '@admin_user_form_submit' %>
+</div>
+
+<% end %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -19,7 +19,7 @@
     <%= f.check_box :admin, {}, true, false %>
     <%= f.label :admin, "管理者権限" %><br>
   </div>
-  <%= f.submit '登録', class: 'btn btn-primary', id: '@admin_user_form_submit' %>
+  <%= f.submit '登録', class: 'btn btn-primary', id: 'admin_user_form_submit' %>
 </div>
 
 <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#edit</h1>
+<p>Find me in app/views/admin/users/edit.html.erb</p>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,2 +1,5 @@
-<h1>Admin::Users#edit</h1>
-<p>Find me in app/views/admin/users/edit.html.erb</p>
+<div class="d-flex align-items-center">
+  <h1>編集</h1>
+</div>
+
+<%= render partial: 'form', locals: { user: @user } %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -22,10 +22,10 @@
      <tr>
        <td id=<%= "users-index__user-#{user.id}-name" %> ><%= user.name %></td>
        <td id=<%= "users-index__user-#{user.id}-email" %> ><%= user.email %></td>
-       <td></td>
+       <td id=<%= "users-index__user-#{user.id}-task-count" %> ><%= user.tasks.count %></td>
        <td id=<%= "users-index__user-#{user.id}-admin" %> ><%= user.admin? ? 'あり' : 'なし' %></td>
        <td id=<%= "users-index__user-#{user.id}-created_at" %> ><%= user.created_at.strftime("%Y年 %m月 %d日 %H:%M:%S") %></td>
-       <td><%= link_to '詳細', user_path(user), class: 'btn btn-primary mr-3'%></td>
+       <td><%= link_to '詳細', admin_user_path(user), class: 'btn btn-primary mr-3'%></td>
        <td><%= link_to '編集', edit_admin_user_path(user), class: 'btn btn-success mr-3'%></td>
        <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: "タスク「#{user.name}を削除します。よろしいでしょうか？」" }, class: 'btn btn-danger mr-3'%></td>
      </tr>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,35 @@
+<div class="d-flex align-items-center">
+  <h1>ユーザー一覧(管理者用)</h1>
+</div>
+  <%= link_to '新規登録', new_admin_user_path, class: 'btn btn-primary'%>
+
+<!-- <div class="col-md-12"> -->
+<table class="table">
+  <thead class="thead-dark">
+    <tr>
+      <th>ユーザー名</th>
+      <th>メールアドレス</th>
+      <th>タスク数</th>
+      <th>管理者権限</th>
+      <th>登録日時</th>
+      <th></th>
+      <th></th>
+      <th></th>
+   </tr>
+ </thead>
+ <tbody>
+   <% @users.each do |user| %>
+     <tr>
+       <td id=<%= "users-index__user-#{user.id}-name" %> ><%= user.name %></td>
+       <td id=<%= "users-index__user-#{user.id}-email" %> ><%= user.email %></td>
+       <td></td>
+       <td id=<%= "users-index__user-#{user.id}-admin" %> ><%= user.admin? ? 'あり' : 'なし' %></td>
+       <td id=<%= "users-index__user-#{user.id}-created_at" %> ><%= user.created_at.strftime("%Y年 %m月 %d日 %H:%M:%S") %></td>
+       <td><%= link_to '詳細', user_path(user), class: 'btn btn-primary mr-3'%></td>
+       <td><%= link_to '編集', edit_admin_user_path(user), class: 'btn btn-success mr-3'%></td>
+       <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: "タスク「#{user.name}を削除します。よろしいでしょうか？」" }, class: 'btn btn-danger mr-3'%></td>
+     </tr>
+   <% end %>
+ </tbody>
+</table>
+<!-- </div> -->

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -27,7 +27,7 @@
        <td id=<%= "users-index__user-#{user.id}-created_at" %> ><%= user.created_at.strftime("%Y年 %m月 %d日 %H:%M:%S") %></td>
        <td><%= link_to '詳細', admin_user_path(user), class: 'btn btn-primary mr-3'%></td>
        <td><%= link_to '編集', edit_admin_user_path(user), class: 'btn btn-success mr-3'%></td>
-       <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: "タスク「#{user.name}を削除します。よろしいでしょうか？」" }, class: 'btn btn-danger mr-3'%></td>
+       <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: "ユーザー「#{user.name}を削除します。よろしいでしょうか？」" }, class: 'btn btn-danger mr-3'%></td>
      </tr>
    <% end %>
  </tbody>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex align-items-center">
   <h1>ユーザー一覧(管理者用)</h1>
 </div>
-  <%= link_to '新規登録', new_admin_user_path, class: 'btn btn-primary'%>
+  <%= link_to '新規登録', new_admin_user_path, class: 'btn btn-primary', id: 'admin_index_new_submit' %>
 
 <!-- <div class="col-md-12"> -->
 <table class="table">
@@ -20,14 +20,14 @@
  <tbody>
    <% @users.each do |user| %>
      <tr>
-       <td id=<%= "users-index__user-#{user.id}-name" %> ><%= user.name %></td>
-       <td id=<%= "users-index__user-#{user.id}-email" %> ><%= user.email %></td>
-       <td id=<%= "users-index__user-#{user.id}-task-count" %> ><%= user.tasks.count %></td>
-       <td id=<%= "users-index__user-#{user.id}-admin" %> ><%= user.admin? ? 'あり' : 'なし' %></td>
-       <td id=<%= "users-index__user-#{user.id}-created_at" %> ><%= user.created_at.strftime("%Y年 %m月 %d日 %H:%M:%S") %></td>
-       <td><%= link_to '詳細', admin_user_path(user), class: 'btn btn-primary mr-3'%></td>
-       <td><%= link_to '編集', edit_admin_user_path(user), class: 'btn btn-success mr-3'%></td>
-       <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: "ユーザー「#{user.name}を削除します。よろしいでしょうか？」" }, class: 'btn btn-danger mr-3'%></td>
+       <td id=<%= "admin-index__user-#{user.id}-name" %> ><%= user.name %></td>
+       <td id=<%= "admin-index__user-#{user.id}-email" %> ><%= user.email %></td>
+       <td id=<%= "admin-index__user-#{user.id}-task-count" %> ><%= user.tasks.count %></td>
+       <td id=<%= "admin-index__user-#{user.id}-admin" %> ><%= user.admin? ? 'あり' : 'なし' %></td>
+       <td id=<%= "admin-index__user-#{user.id}-created_at" %> ><%= user.created_at.strftime("%Y年 %m月 %d日 %H:%M:%S") %></td>
+       <td><%= link_to '詳細', admin_user_path(user), class: 'btn btn-primary mr-3', id: "admin-index_detail-#{user.id}-submit" %></td>
+       <td><%= link_to '編集', edit_admin_user_path(user), class: 'btn btn-success mr-3', id: "admin_index_edit-#{user.id}-submit" %></td>
+       <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: "ユーザー「#{user.name}を削除します。よろしいでしょうか？」" }, class: 'btn btn-danger mr-3', id: "admin_index_delete-#{user.id}-submit" %></td>
      </tr>
    <% end %>
  </tbody>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,28 @@
+<div class="d-flex align-items-center">
+  <h1>新規登録</h1>
+</div>
+
+<% if @user.errors.any? %>
+  <div id="error_explanation" class="alert-danger">
+    <h2><%= @user.errors.count %>件のエラーがあります。</h2>
+    <ul>
+    <% @user.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+<div class="col-md-4">
+<%= form_with(model: [:admin, @user], local: true) do |f| %>
+  <div class="form-group">
+    <%= f.text_field :name, placeholder:"名前", class: 'form-control' %><br>
+    <%= f.email_field :email, placeholder:"メールアドレス", class: 'form-control' %><br>
+    <%= f.password_field :password, placeholder:"パスワード", class: 'form-control' %><br>
+    <%= f.password_field :password_confirmation, placeholder:"パスワード確認", class: 'form-control' %><br>
+    <%= f.hidden_field :admin, value: false %>
+    <%= f.check_box :admin, {}, true, false %>
+    <%= f.label :admin, "管理者権限" %><br>
+  </div>
+</div>
+  <%= f.submit '登録', value:'登録', class: 'btn btn-primary', id: '@user_form_submit' %>
+<% end %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -2,27 +2,4 @@
   <h1>新規登録</h1>
 </div>
 
-<% if @user.errors.any? %>
-  <div id="error_explanation" class="alert-danger">
-    <h2><%= @user.errors.count %>件のエラーがあります。</h2>
-    <ul>
-    <% @user.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
-    <% end %>
-    </ul>
-  </div>
-<% end %>
-<div class="col-md-4">
-<%= form_with(model: [:admin, @user], local: true) do |f| %>
-  <div class="form-group">
-    <%= f.text_field :name, placeholder:"名前", class: 'form-control' %><br>
-    <%= f.email_field :email, placeholder:"メールアドレス", class: 'form-control' %><br>
-    <%= f.password_field :password, placeholder:"パスワード", class: 'form-control' %><br>
-    <%= f.password_field :password_confirmation, placeholder:"パスワード確認", class: 'form-control' %><br>
-    <%= f.hidden_field :admin, value: false %>
-    <%= f.check_box :admin, {}, true, false %>
-    <%= f.label :admin, "管理者権限" %><br>
-  </div>
-</div>
-  <%= f.submit '登録', value:'登録', class: 'btn btn-primary', id: '@user_form_submit' %>
-<% end %>
+<%= render partial: 'form', locals: { user: @user } %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#show</h1>
+<p>Find me in app/views/admin/users/show.html.erb</p>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,2 +1,22 @@
-<h1>Admin::Users#show</h1>
-<p>Find me in app/views/admin/users/show.html.erb</p>
+<h1>ユーザー詳細</h1>
+
+<div class="col-md-4">
+<table class="table">
+  <tbody class="thead">
+    <tr>
+      <th>ユーザー名</th>
+      <td id=<%= "admin_user-show__user-#{@user.id}-name" %> ><%= @user.name %></td>
+    </tr>
+    <tr>
+      <th>email</th>
+      <td id=<%= "admin_user-show__user-#{@user.id}-email" %> ><%= @user.email %></td>
+    </tr>
+    <tr>
+      <th>タスク数</th>
+      <td id=<%= "admin_user-show__user-#{@user.id}-tasks_count" %> ><%= @user.tasks.count %></td>
+    </tr>
+    </tbody>
+ </table>
+ <td><%= link_to '編集', edit_admin_user_path(@user), class: 'btn btn-success'%></td>
+ <td><%= link_to '削除',admin_user_path(@user), method: :delete, class: 'btn btn-danger mr-3', date: {confirm: "タスク「#{@user.name}」を削除します。よろしいでしょうか？"}%></td>
+</div>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -7,7 +7,7 @@
 <div class="collapse navbar-collapse" id="navbarSupportedContent">
 <ul class="navbar-nav mr-auto">
   <li class="nav-item">
-     <%= link_to '投稿一覧', tasks_path, class: 'nav-link' %>
+     <%= link_to 'タスク一覧', tasks_path, class: 'nav-link' %>
   </li>
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,0 +1,27 @@
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+<a class="navbar-brand" href="#">タスク管理</a>
+<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+<span class="navbar-toggler-icon"></span>
+</button>
+
+<div class="collapse navbar-collapse" id="navbarSupportedContent">
+<ul class="navbar-nav mr-auto">
+  <li class="nav-item">
+     <%= link_to '投稿一覧', tasks_path, class: 'nav-link' %>
+  </li>
+  <li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      ユーザー
+    </a>
+    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+      <% if logged_in? %>
+        <%= link_to 'マイページ', user_path(current_user.id), class: 'dropdown-item' %>
+        <%= link_to 'ログアウト', session_path(current_user.id), method: :delete, class: 'dropdown-item' %>
+      <% else %>
+        <%= link_to '登録', new_user_path, class: 'dropdown-item' %>
+        <%= link_to 'ログイン', new_session_path, class: 'dropdown-item' %>
+      <% end %>
+    </div>
+  </li>
+</div>
+</nav>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -23,7 +23,7 @@
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <% if logged_in? %>
         <%= link_to 'マイページ', user_path(current_user.id), class: 'dropdown-item' %>
-        <%= link_to 'ログアウト', session_path(current_user.id), method: :delete, class: 'dropdown-item' %>
+        <%= link_to 'ログアウト', session_path(current_user.id), method: :delete, class: 'dropdown-item', id:'header_nav_submit' %>
       <% else %>
         <%= link_to '登録', new_user_path, class: 'dropdown-item' %>
         <%= link_to 'ログイン', new_session_path, class: 'dropdown-item' %>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -13,9 +13,13 @@
      <%= link_to '管理者画面', admin_users_path, class: 'nav-link' %>
   </li>
   <li class="nav-item dropdown">
+    <% if logged_in? %>
     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      ユーザー
-    </a>
+    <%= current_user.name %>さん</a>
+    <% else %>
+    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    こんにちは、ログイン</a>
+    <% end %>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <% if logged_in? %>
         <%= link_to 'マイページ', user_path(current_user.id), class: 'dropdown-item' %>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -9,6 +9,9 @@
   <li class="nav-item">
      <%= link_to 'タスク一覧', tasks_path, class: 'nav-link' %>
   </li>
+  <li class="nav-item">
+     <%= link_to '管理者画面', admin_users_path, class: 'nav-link' %>
+  </li>
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       ユーザー

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
     <%= render 'header' %>
-    <div class="container">
+    <div class="container col-md-10">
       <div class="col-md-4">
       <% if flash[:notice] %>
         <p class="alert alert-primary"><%= flash[:notice] %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   </head>
 
   <body>
+    <%= render 'header' %>
     <div class="container">
       <% if flash[:notice] %>
         <p class="alert alert-primary"><%= flash[:notice] %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
   <body>
     <%= render 'header' %>
     <div class="container">
+      <div class="col-md-4">
       <% if flash[:notice] %>
         <p class="alert alert-primary"><%= flash[:notice] %></p>
       <% end %>
@@ -21,6 +22,7 @@
       <% if flash[:danger] %>
         <p class="alert alert-danger"><%= flash[:danger] %></p>
       <% end %>
+      </div>
     <%= yield %>
     </div>
   </body>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -8,5 +8,5 @@
       <%= f.email_field :email, placeholder:"メールアドレス", class: 'form-control' %><br>
       <%= f.password_field :password, placeholder:"パスワード", class: 'form-control' %>
     </div>
-  <%= f.submit 'ログイン', value:'ログイン', class: 'btn btn-primary', id: '@session_form_submit' %>
+  <%= f.submit 'ログイン', value:'ログイン', class: 'btn btn-primary', id: 'session_form_submit' %>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,12 @@
+<div class="d-flex align-items-center">
+  <h1>ログイン</h1>
+</div>
+
+<div class="col-md-4">
+  <%= form_with(scope: :session, url: sessions_path, local: true) do |f| %>
+    <div class="form-group">
+      <%= f.email_field :email, placeholder:"メールアドレス", class: 'form-control' %><br>
+      <%= f.password_field :password, placeholder:"パスワード", class: 'form-control' %>
+    </div>
+  <%= f.submit 'ログイン', value:'ログイン', class: 'btn btn-primary', id: '@session_form_submit' %>
+<% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -8,7 +8,7 @@
     </ul>
   </div>
 <% end %>
-<%= link_to 'タスク一覧', tasks_path, class: 'btn btn-primary'%>
+
 <%= form_with(model: task, local: true) do |f| %>
   <div class="form-group">
     <%= f.label :タスク名 %>

--- a/app/views/tasks/destroy.html.erb
+++ b/app/views/tasks/destroy.html.erb
@@ -1,2 +1,1 @@
-<h1>Tasks#destroy</h1>
-<p>Find me in app/views/tasks/destroy.html.erb</p>
+

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex align-items-center">
-  <h1>投稿一覧</h1>
+  <h1>タスク一覧</h1>
 </div>
   <%= link_to '新規登録', new_task_path, class: 'btn btn-primary'%>
 <ul>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,7 +17,7 @@
 <table class="table">
   <thead class="thead-dark">
     <tr>
-      <th>タスク名</th>
+      <th>タスク</th>
       <th>詳しい内容</th>
       <th><%= link_to "終了期限", tasks_path(sort_expired: "true") %></th>
       <th>登録日時</th>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -23,6 +23,7 @@
       <th>登録日時</th>
       <th>ステータス</th>
       <th><%= link_to "優先度", tasks_path(sort_priority: "true") %></th>
+      <th>作成者</th>
       <th></th>
       <th></th>
       <th></th>
@@ -37,6 +38,7 @@
        <td id=<%= "tasks-index__task-#{task.id}-created_at" %> ><%= task.created_at.strftime("%Y年 %m月 %d日 %H:%M:%S") %></td>
        <td id=<%= "tasks-index__task-#{task.id}-status" %> ><%= task.status %></td>
        <td id=<%= "tasks-index__task-#{task.id}-priority" %> ><%= task.priority %></td>
+       <td id=<%= "tasks-index__task-#{task.id}-user_name" %> ><%= task.user.name %></td>
        <td><%= link_to '詳細', task_path(task), class: 'btn btn-primary mr-3'%></td>
        <td><%= link_to '編集', edit_task_path(task), class: 'btn btn-success mr-3'%></td>
        <td><%= link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.title}を削除します。よろしいでしょうか？」" }, class: 'btn btn-danger mr-3'%></td>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -16,9 +16,9 @@
 <%= form_with(model: @user, local: true) do |f| %>
   <div class="form-group">
     <%= f.text_field :name, placeholder:"名前", class: 'form-control' %><br>
-    <%= f.text_field :email, placeholder:"メールアドレス", class: 'form-control' %><br>
-    <%= f.text_field :password, placeholder:"パスワード", class: 'form-control' %><br>
-    <%= f.text_field :password_confirmation, placeholder:"パスワード確認", class: 'form-control' %>
+    <%= f.email_field :email, placeholder:"メールアドレス", class: 'form-control' %><br>
+    <%= f.password_field :password, placeholder:"パスワード", class: 'form-control' %><br>
+    <%= f.password_field :password_confirmation, placeholder:"パスワード確認", class: 'form-control' %>
   </div>
 </div>
   <%= f.submit '登録', value:'登録', class: 'btn btn-primary', id: '@user_form_submit' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -21,5 +21,5 @@
     <%= f.password_field :password_confirmation, placeholder:"パスワード確認", class: 'form-control' %>
   </div>
 </div>
-  <%= f.submit '登録', value:'登録', class: 'btn btn-primary', id: '@user_form_submit' %>
+  <%= f.submit '登録', value:'登録', class: 'btn btn-primary', id: 'user_form_submit' %>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,25 @@
+<div class="d-flex align-items-center">
+  <h1>新規登録</h1>
+</div>
+
+<% if @user.errors.any? %>
+  <div id="error_explanation" class="alert-danger">
+    <h2><%= @user.errors.count %>件のエラーがあります。</h2>
+    <ul>
+    <% @user.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+<div class="col-md-4">
+<%= form_with(model: @user, local: true) do |f| %>
+  <div class="form-group">
+    <%= f.text_field :name, placeholder:"名前", class: 'form-control' %><br>
+    <%= f.text_field :email, placeholder:"メールアドレス", class: 'form-control' %><br>
+    <%= f.text_field :password, placeholder:"パスワード", class: 'form-control' %><br>
+    <%= f.text_field :password_confirmation, placeholder:"パスワード確認", class: 'form-control' %>
+  </div>
+</div>
+  <%= f.submit '登録', value:'登録', class: 'btn btn-primary', id: '@user_form_submit' %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,15 @@
+<h1>マイページ</h1>
+<div class="col-md-4">
+<table class="table">
+  <tbody class="thead">
+    <tr>
+      <th>ユーザー名</th>
+      <td id=<%= "users-show__task-#{@user.id}-title" %> ><%= @user.name %></td>
+    </tr>
+    <tr>
+      <th>メールアドレス</th>
+      <td id=<%= "users-show__task-#{@user.id}-content" %> ><%= @user.email %></td>
+    </tr>
+  </tbody>
+ </table>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,11 +4,11 @@
   <tbody class="thead">
     <tr>
       <th>ユーザー名</th>
-      <td id=<%= "users-show__task-#{@user.id}-title" %> ><%= @user.name %></td>
+      <td id=<%= "users-show__user-#{@user.id}-name" %> ><%= @user.name %></td>
     </tr>
     <tr>
       <th>メールアドレス</th>
-      <td id=<%= "users-show__task-#{@user.id}-content" %> ><%= @user.email %></td>
+      <td id=<%= "users-show__user-#{@user.id}-email" %> ><%= @user.email %></td>
     </tr>
   </tbody>
  </table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,4 +12,35 @@
     </tr>
   </tbody>
  </table>
-</div>
+ </div>
+
+ <table class="table">
+   <thead class="thead-dark">
+     <tr>
+       <th>タスク</th>
+       <th>詳しい内容</th>
+       <th>終了期限</th>
+       <th>登録日時</th>
+       <th>ステータス</th>
+       <th>優先度</th>
+       <th></th>
+       <th></th>
+       <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @user.tasks.each do |task| %>
+      <tr>
+        <td id=<%= "users-show__task-#{task.id}-title" %> ><%= link_to task.title, task %></td>
+        <td id=<%= "users-show__task-#{task.id}-content" %> ><%= task.content %></td>
+        <td id=<%= "users-show__task-#{task.id}-deadline" %> ><%= task.deadline.strftime('%Y年 %m月 %d日') %></td>
+        <td id=<%= "users-show__task-#{task.id}-created_at" %> ><%= task.created_at.strftime("%Y年 %m月 %d日 %H:%M:%S") %></td>
+        <td id=<%= "users-show__task-#{task.id}-status" %> ><%= task.status %></td>
+        <td id=<%= "users-show__task-#{task.id}-priority" %> ><%= task.priority %></td>
+        <td><%= link_to '詳細', task_path(task), class: 'btn btn-primary mr-3'%></td>
+        <td><%= link_to '編集', edit_task_path(task), class: 'btn btn-success mr-3'%></td>
+        <td><%= link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.title}を削除します。よろしいでしょうか？」" }, class: 'btn btn-danger mr-3'%></td>
+      </tr>
+    <% end %>
+  </tbody>
+ </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'tasks#index'
   resources :tasks
+  resources :users, only: [:new, :create]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
+  get 'sessions/new'
   root 'tasks#index'
   resources :tasks
-  resources :users, only: [:new, :create]
+  resources :sessions, only: [:new, :create, :destroy]
+  resources :users, only: [:new, :create, :show]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+  end
+
   root 'tasks#index'
   resources :tasks
   resources :users, only: [:new, :create, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
-  get 'sessions/new'
   root 'tasks#index'
   resources :tasks
-  resources :sessions, only: [:new, :create, :destroy]
   resources :users, only: [:new, :create, :show]
+  resources :sessions, only: [:new, :create, :destroy]
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20210211075646_create_users.rb
+++ b/db/migrate/20210211075646_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210211081649_change_notnull_to_users.rb
+++ b/db/migrate/20210211081649_change_notnull_to_users.rb
@@ -1,0 +1,7 @@
+class ChangeNotnullToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :users, :name, false
+    change_column_null :users, :email, false
+    change_column_null :users, :password_digest, false
+  end
+end

--- a/db/migrate/20210211082009_add_index_users.rb
+++ b/db/migrate/20210211082009_add_index_users.rb
@@ -1,0 +1,5 @@
+class AddIndexUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20210211083127_add_user_ref_to_tasks.rb
+++ b/db/migrate/20210211083127_add_user_ref_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserRefToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20210211100947_add_admin_to_users.rb
+++ b/db/migrate/20210211100947_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false, null:false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_11_083127) do
+ActiveRecord::Schema.define(version: 2021_02_11_100947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_083127) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_11_075646) do
+ActiveRecord::Schema.define(version: 2021_02_11_083127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,16 +23,20 @@ ActiveRecord::Schema.define(version: 2021_02_11_075646) do
     t.integer "priority", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "password_digest"
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "tasks", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_08_110147) do
+ActiveRecord::Schema.define(version: 2021_02_11_075646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,14 @@ ActiveRecord::Schema.define(version: 2021_02_08_110147) do
     t.datetime "updated_at", null: false
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+User.find_or_create_by!(email: 'admin@example.com') do |user|
+  user.name = 'admin'
+  user.admin = true
+  user.password = 'password'
+  user.password_confirmation = 'password'
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { "MyString" }
+    email { "MyString" }
+    password_digest { "MyString" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,24 @@
 FactoryBot.define do
-  factory :user do
-    name { "MyString" }
-    email { "MyString" }
-    password_digest { "MyString" }
+  factory :admin_user do
+    name { "admin" }
+    email { "admin@example.com" }
+    password { "password" }
+    password_confirmation {"password"}
+    admin { true }
   end
+  factory :user1, class: User do
+    name { "user1" }
+    email { "user1@example.com" }
+    password { "password1" }
+    password_confirmation {"password1"}
+    admin { false }
+  end
+  factory :user2, class: User do
+    name { "user2" }
+    email { "user2@example.com" }
+    password { "password2" }
+    password_confirmation {"password2"}
+    admin { false }
+  end
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :admin_user do
+  factory :admin_user, class: User do
     name { "admin" }
     email { "admin@example.com" }
     password { "password" }
@@ -12,6 +12,7 @@ FactoryBot.define do
     password { "password1" }
     password_confirmation {"password1"}
     admin { false }
+    id { 1 }
   end
   factory :user2, class: User do
     name { "user2" }
@@ -19,6 +20,7 @@ FactoryBot.define do
     password { "password2" }
     password_confirmation {"password2"}
     admin { false }
+    id { 2 }
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -38,7 +38,7 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
-
+  config.include ApplicationHelpers
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 

--- a/spec/support/application_helper.rb
+++ b/spec/support/application_helper.rb
@@ -1,0 +1,6 @@
+module ApplicationHelpers
+
+  def is_logged_in?
+    !session[:user_id].nil?
+  end
+end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 RSpec.describe 'ユーザー管理機能', type: :system do
-  before do
-    # FactoryBot.create(:admin_user)
-    FactoryBot.create(:user1)
-    FactoryBot.create(:user2)
-  end
+    let!(:admin_user){ FactoryBot.create(:admin_user) }
+    let!(:user1){ FactoryBot.create(:user1) }
+    let!(:user2){ FactoryBot.create(:user2) }
+
   describe 'ユーザー登録機能' do
     context 'ユーザーを新規作成した場合' do
       it '作成したユーザーが表示される' do
         visit new_user_path
-        user = User.new(name: "name", email: "content@example.com", password: "password", password_confirmation: "password")
+        user = User.new(name: "name", email: "user@example.com", password: "password", password_confirmation: "password")
         fill_in 'user[name]', with: user.name
         fill_in 'user[email]', with: user.email
         fill_in 'user[password]', with: user.password
@@ -29,50 +28,99 @@ RSpec.describe 'ユーザー管理機能', type: :system do
      end
     end
   end
-  # describe '一覧表示機能' do
-  #   context '一覧画面に遷移した場合' do
-  #     it '作成済みのタスク一覧が表示される' do
-  #      visit tasks_path
-  #      expect(page).to have_content 'new_task'
-  #     end
-  #   end
-  #   context 'タスクが作成日時の降順に並んでいる場合' do
-  #     it '新しいタスクが一番上に表示される' do
-  #       visit tasks_path
-  #       task_list = all('tbody tr')
-  #       expect(task_list[0]).to have_content 'new_task'
-  #       expect(task_list[1]).to have_content 'task'
-  #     end
-  #   end
-  #   context '終了期限でソートした場合' do
-  #     it 'タスクが終了期限順に並んでいる' do
-  #       visit tasks_path
-  #       click_on '終了期限'
-  #       sleep(1)
-  #       task_list = all('tbody tr')
-  #       expect(task_list[0]).to have_content 'task'
-  #       expect(task_list[1]).to have_content 'new_task'
-  #     end
-  #   end
-  #   context '優先順位が高い順でソートした場合' do
-  #     it 'タスクが優先順が高い順に並んでいる' do
-  #       visit tasks_path
-  #       click_on '優先度'
-  #       sleep(1)
-  #       task_list = all('tbody tr')
-  #       expect(task_list[0]).to have_content 'high'
-  #       expect(task_list[1]).to have_content 'low'
-  #     end
-  #   end
-  # end
-  # describe '詳細表示機能' do
-  #    context '任意のタスク詳細画面に遷移した場合' do
-  #      it '該当タスクの内容が表示される' do
-  #        visit task_path(1)
-  #        expect(page).to have_content 'task'
-  #        visit task_path(2)
-  #        expect(page).to have_content 'new_task'
-  #      end
-  #    end
-  # end
+  describe 'ログインとログアウト' do
+    context 'ログインした場合' do
+      before do
+        visit new_session_path
+        fill_in 'session[email]', with: user1.email
+        fill_in 'session[password]', with: user1.password
+        click_on 'session_form_submit'
+        sleep(1)
+      end
+      it '自分の詳細画面に飛ぶ' do
+        expect(find_by_id("users-show__user-#{user1.id}-name")).to have_content user1.name
+        expect(find_by_id("users-show__user-#{user1.id}-email")).to have_content user1.email
+      end
+      it '一般ユーザが他人の詳細画面に飛ぶとタスク一覧画面に遷移する' do
+        visit user_path(user2)
+        expect(page).to have_content '閲覧権限がありません'
+        expect(current_path).to eq tasks_path
+      end
+      it 'ログアウトできる' do
+        click_on 'navbarDropdown'
+        click_on 'header_nav_submit'
+        sleep(1)
+        expect(current_path).to eq new_session_path
+        # expect(is_logged_in?).to be_falsy
+      end
+    end
+  end
+  describe '管理者機能' do
+    context '一般ユーザーの場合' do
+      it '管理画面にアクセスできない' do
+        visit new_session_path
+        fill_in 'session[email]', with: user1.email
+        fill_in 'session[password]', with: user1.password
+        click_on 'session_form_submit'
+        sleep(1)
+        visit admin_users_path
+        expect(page).to have_content '権限がありません'
+      end
+    end
+    context '管理者の場合' do
+      before do
+        visit new_session_path
+        fill_in 'session[email]', with: admin_user.email
+        fill_in 'session[password]', with: admin_user.password
+        click_on 'session_form_submit'
+        sleep(1)
+      end
+      it '管理画面にアクセスできる' do
+        visit admin_users_path
+        expect(page).to have_content 'ユーザー一覧(管理者用)'
+      end
+      it 'ユーザーの新規登録ができる' do
+        visit new_admin_user_path
+        user = User.new(name: "name", email: "user@example.com", password: "password", password_confirmation: "password")
+        fill_in 'user[name]', with: user.name
+        fill_in 'user[email]', with: user.email
+        fill_in 'user[password]', with: user.password
+        fill_in 'user[password_confirmation]', with: user.password_confirmation
+        click_on 'admin_user_form_submit'
+        sleep(1)
+        result = User.last
+        expect(find_by_id("admin_user-show__user-#{result.id}-name")).to have_content user.name
+        expect(find_by_id("admin_user-show__user-#{result.id}-email")).to have_content user.email
+        expect(find_by_id("admin_user-show__user-#{result.id}-tasks_count")).to have_content user.tasks.count
+      end
+      it 'ユーザーの詳細画面にアクセスできる'do
+        visit admin_users_path
+        click_on "admin-index_detail-#{user1.id}-submit"
+        expect(find_by_id("admin_user-show__user-#{user1.id}-name")).to have_content user1.name
+        expect(find_by_id("admin_user-show__user-#{user1.id}-email")).to have_content user1.email
+        expect(find_by_id("admin_user-show__user-#{user1.id}-tasks_count")).to have_content user1.tasks.count
+      end
+      it 'ユーザの編集画面からユーザを編集できる'do
+        visit admin_users_path
+        click_on "admin_index_edit-#{user1.id}-submit"
+        user = User.new(name: "name3", email: "user3@example.com", password: "password3", password_confirmation: "password3")
+        fill_in 'user[name]', with: user.name
+        fill_in 'user[email]', with: user.email
+        fill_in 'user[password]', with: user.password
+        fill_in 'user[password_confirmation]', with: user.password_confirmation
+        click_on 'admin_user_form_submit'
+        sleep(1)
+        expect(find_by_id("admin_user-show__user-#{user1.id}-name")).to have_content user.name
+        expect(find_by_id("admin_user-show__user-#{user1.id}-email")).to have_content user.email
+      end
+      it 'ユーザーを削除できる'do
+        visit admin_users_path
+        click_on "admin_index_delete-#{user1.id}-submit"
+        page.driver.browser.switch_to.alert.accept
+        expect(page).not_to have_content user1.email
+        expect(page).to have_content user2.email
+        expect(page).to have_content admin_user.email
+      end
+    end
+  end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+RSpec.describe 'ユーザー管理機能', type: :system do
+  before do
+    # FactoryBot.create(:admin_user)
+    FactoryBot.create(:user1)
+    FactoryBot.create(:user2)
+  end
+  describe 'ユーザー登録機能' do
+    context 'ユーザーを新規作成した場合' do
+      it '作成したユーザーが表示される' do
+        visit new_user_path
+        user = User.new(name: "name", email: "content@example.com", password: "password", password_confirmation: "password")
+        fill_in 'user[name]', with: user.name
+        fill_in 'user[email]', with: user.email
+        fill_in 'user[password]', with: user.password
+        fill_in 'user[password_confirmation]', with: user.password_confirmation
+        click_on 'user_form_submit'
+        sleep(1)
+        result = User.last
+        expect(find_by_id("users-show__user-#{result.id}-name")).to have_content user.name
+        expect(find_by_id("users-show__user-#{result.id}-email")).to have_content user.email
+        end
+      end
+    context 'ログインしていない場合' do
+      it 'ログインせずタスク一覧画面に飛ぼうとしたとき、ログイン画面に遷移する' do
+       visit tasks_path
+       expect(page).to have_content 'ログインが必要です！'
+       expect(current_path).to eq new_session_path
+     end
+    end
+  end
+  # describe '一覧表示機能' do
+  #   context '一覧画面に遷移した場合' do
+  #     it '作成済みのタスク一覧が表示される' do
+  #      visit tasks_path
+  #      expect(page).to have_content 'new_task'
+  #     end
+  #   end
+  #   context 'タスクが作成日時の降順に並んでいる場合' do
+  #     it '新しいタスクが一番上に表示される' do
+  #       visit tasks_path
+  #       task_list = all('tbody tr')
+  #       expect(task_list[0]).to have_content 'new_task'
+  #       expect(task_list[1]).to have_content 'task'
+  #     end
+  #   end
+  #   context '終了期限でソートした場合' do
+  #     it 'タスクが終了期限順に並んでいる' do
+  #       visit tasks_path
+  #       click_on '終了期限'
+  #       sleep(1)
+  #       task_list = all('tbody tr')
+  #       expect(task_list[0]).to have_content 'task'
+  #       expect(task_list[1]).to have_content 'new_task'
+  #     end
+  #   end
+  #   context '優先順位が高い順でソートした場合' do
+  #     it 'タスクが優先順が高い順に並んでいる' do
+  #       visit tasks_path
+  #       click_on '優先度'
+  #       sleep(1)
+  #       task_list = all('tbody tr')
+  #       expect(task_list[0]).to have_content 'high'
+  #       expect(task_list[1]).to have_content 'low'
+  #     end
+  #   end
+  # end
+  # describe '詳細表示機能' do
+  #    context '任意のタスク詳細画面に遷移した場合' do
+  #      it '該当タスクの内容が表示される' do
+  #        visit task_path(1)
+  #        expect(page).to have_content 'task'
+  #        visit task_path(2)
+  #        expect(page).to have_content 'new_task'
+  #      end
+  #    end
+  # end
+end


### PR DESCRIPTION
- [x] ユーザモデルを作成する
- [x] 最初のユーザをseedで作成する
- [x] ユーザとタスクを紐づける
- [x] ユーザのemailにユニーク制約をつける
- [x] 関連（アソシエーションで使用するid）に対してインデックスをつける
- [ ] Herokuにデプロイした際に、すでに登録されているタスクとユーザが紐づいているようにする
- [x] bcrypt-ruby以外は、Gemを使わずに実装する
- [x] ログイン機能を実装する
- [x] ログインをせずにタスク一覧のページに飛ぼうとしたときは、ログインページに遷移させる
- [x] 自分が作成したタスクだけを表示させる
- [x] ログアウト機能を実装する
- [x] ユーザの新規登録画面、ログイン画面、詳細・マイページ（show）画面を作成する
- [x] ユーザを新規登録（create）をしたとき、同時にログインもさせる
- [x] ログインしているときは、ユーザの新規登録画面（new画面）に行かせないようにコントローラで制御する
- [x] 自分（current_user）以外のユーザのマイページ（userのshow画面）にアクセスしたらタスク一覧に遷移させる
- [x] 管理画面を追加する
- [x] 管理画面にはかならず /admin というURLを先頭につける
- [x] 管理画面でユーザ一覧表示・作成・更新・削除ができる（管理画面のビューは、パーシャル化しなくても構わない）
- [x] ユーザを削除したら、そのユーザに紐づいているタスクを全て削除する
- [x] ユーザの一覧画面で、そのユーザに紐づいているタスクの数を表示する
- [x] N+1問題を回避するための仕組みを取り入れること
- [x] ユーザが作成したタスクの一覧を、そのユーザのマイページ（userのshow画面）で見られる
- [x] ユーザを管理ユーザと一般ユーザを区別する
- [x] 管理ユーザだけがユーザ管理画面にアクセスできる
- [x] 一般ユーザが管理画面にアクセスしたとき、tasks/indexに飛ばして「管理者以外はアクセスできない」旨のflashメッセージを出力する
- [x] ユーザ管理画面でロールの付与と削除ができる
- [x] 管理ユーザが一人もいなくなってしまわないように、モデルのコールバックを利用して更新・削除の制御をする
- [x] テスト項目を満たすようSystem Specを書く
- [x] ユーザ登録のテスト
- [x] ユーザの新規登録ができること
- [x] ユーザがログインせずタスク一覧画面に飛ぼうとしたとき、ログイン画面に遷移すること
- [x] セッション機能のテスト
- [x] ログインができること
- [x] 自分の詳細画面(マイページ)に飛べること
- [x] 一般ユーザが他人の詳細画面に飛ぶとタスク一覧画面に遷移すること
- [x] ログアウトができること
- [x] 管理画面のテスト
- [x] 管理ユーザは管理画面にアクセスできること
- [x] 一般ユーザは管理画面にアクセスできないこと
- [x] 管理ユーザはユーザの新規登録ができること
- [x] 管理ユーザはユーザの詳細画面にアクセスできること
- [x] 管理ユーザはユーザの編集画面からユーザを編集できること
- [x] 管理ユーザはユーザの削除をできること